### PR TITLE
Include missing files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include *.md


### PR DESCRIPTION
Include missing files in sdist for #5

Tested with

```
++ mktemp -d
+ D=/tmp/tmp.9T1tCl7II1
+ trap 'rm -rf /tmp/tmp.9T1tCl7II1' EXIT
+ python -m venv /tmp/tmp.9T1tCl7II1
+ python setup.py sdist -d /tmp/tmp.9T1tCl7II1
running sdist
running egg_info
writing detest.egg-info/PKG-INFO
writing dependency_links to detest.egg-info/dependency_links.txt
writing top-level names to detest.egg-info/top_level.txt
reading manifest file 'detest.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'detest.egg-info/SOURCES.txt'
warning: sdist: standard file not found: should have one of README, README.rst, README.txt, README.md

running check
warning: Check: missing meta-data: if 'author' supplied, 'author_email' must be supplied too

creating detest-0.2
creating detest-0.2/detest
creating detest-0.2/detest.egg-info
creating detest-0.2/detest/oracles
copying files to detest-0.2...
copying MANIFEST.in -> detest-0.2
copying Readme.md -> detest-0.2
copying setup.py -> detest-0.2
copying detest/ConvergenceTest.py -> detest-0.2/detest
copying detest/ExactTest.py -> detest-0.2/detest
copying detest/TestRunner.py -> detest-0.2/detest
copying detest/TestingSuite.py -> detest-0.2/detest
copying detest/__init__.py -> detest-0.2/detest
copying detest/vtkutil.py -> detest-0.2/detest
copying detest.egg-info/PKG-INFO -> detest-0.2/detest.egg-info
copying detest.egg-info/SOURCES.txt -> detest-0.2/detest.egg-info
copying detest.egg-info/dependency_links.txt -> detest-0.2/detest.egg-info
copying detest.egg-info/top_level.txt -> detest-0.2/detest.egg-info
copying detest/oracles/__init__.py -> detest-0.2/detest/oracles
copying detest/oracles/deLeeuw.py -> detest-0.2/detest/oracles
copying detest/oracles/heat_equation.py -> detest-0.2/detest/oracles
copying detest/oracles/heat_equation_1d.py -> detest-0.2/detest/oracles
copying detest/oracles/mechanics_constant.py -> detest-0.2/detest/oracles
copying detest/oracles/nonlinear_pendulum.py -> detest-0.2/detest/oracles
copying detest/oracles/odes.py -> detest-0.2/detest/oracles
copying detest/oracles/poroelastic_constant.py -> detest-0.2/detest/oracles
copying detest/oracles/poroelastic_well.py -> detest-0.2/detest/oracles
copying detest/oracles/single_phase_well.py -> detest-0.2/detest/oracles
copying detest/oracles/square_poisson.py -> detest-0.2/detest/oracles
copying detest/oracles/terzaghi.py -> detest-0.2/detest/oracles
copying detest/oracles/thin_crack.py -> detest-0.2/detest/oracles
copying detest/oracles/wave_equation_1d.py -> detest-0.2/detest/oracles
Writing detest-0.2/setup.cfg
Creating tar archive
removing 'detest-0.2' (and everything under it)
+ cd /
+ /tmp/tmp.9T1tCl7II1/bin/pip install /tmp/tmp.9T1tCl7II1/detest-0.2.tar.gz
Processing /tmp/tmp.9T1tCl7II1/detest-0.2.tar.gz
Installing collected packages: detest
  Running setup.py install for detest: started
    Running setup.py install for detest: finished with status 'done'
Successfully installed detest-0.2
WARNING: You are using pip version 19.2.3, however version 20.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
+ echo Success
Success
++ rm -rf /tmp/tmp.9T1tCl7II1
```
